### PR TITLE
add spec for setting array value via atomic update

### DIFF
--- a/sunspot/spec/integration/atomic_updates_spec.rb
+++ b/sunspot/spec/integration/atomic_updates_spec.rb
@@ -44,6 +44,16 @@ describe 'Atomic Update feature' do
     validate_hit(find_indexed_post(post2.id), title: 'A Second Title', featured: true)
   end
 
+  it 'sets array value' do
+    post = Post.new(title: 'A Title', tags: %w(tag1 tag2))
+    Sunspot.index!(post)
+    validate_hit(find_indexed_post(post.id), title: post.title, tag_list: post.tags)
+
+    updated_array = %w(tag3 tag4)
+    Sunspot.atomic_update!(Post, post.id => { tag_list: updated_array })
+    validate_hit(find_indexed_post(post.id), title: post.title, tag_list: updated_array)
+  end
+
   it 'clears field value properly' do
     post = Post.new(title: 'A Title', tags: %w(tag1 tag2), featured: true)
     Sunspot.index!(post)


### PR DESCRIPTION
### Description

In this pull request, changes have been made to the `atomic_updates_spec.rb` file in the Sunspot gem's integration tests. The changes include adding a new test case 'sets array value' to test updating an indexed post with an array value using Sunspot's `atomic_update!` method.

Summary of changes:
- Added a new test case 'sets array value' to test updating an indexed post's array field.
- Created a post with an array of tags, indexed it, updated the tags array using `atomic_update!`, and validated the updated array in the index.
- This change enhances the test coverage for array value updates in the Sunspot gem's integration tests.

These changes introduce a new test case to cover updating an indexed post's array field with a new array value.